### PR TITLE
Adding include unistd.h for open, write, close funcs

### DIFF
--- a/src/schedulers-android.cpp
+++ b/src/schedulers-android.cpp
@@ -16,6 +16,7 @@
 #include <android/looper.h>
 #include <fcntl.h>
 #include <cerrno>
+#include <unistd.h>
 
 using namespace schedulers;
 


### PR DESCRIPTION
This was necessary to work with NDK 18b. I assume older NDKs versions had these functions in a different place.